### PR TITLE
fix(release): stamp versions after lint/test to avoid biome formatting failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,23 +78,27 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      # The tag is the single source of truth for the version, so stamp it onto every workspace
-      # package. pnpm rewrites the internal `workspace:*` dependencies to this version on publish.
-      - name: Set package versions from tag
-        run: pnpm -r exec -- npm pkg set version="${{ steps.version.outputs.version }}"
-
       - name: Build
         run: pnpm build
 
       # Re-run the full suite against the exact tagged commit before publishing. CI already gates
       # merges to master, but a tag can point at any commit and npm versions cannot be unpublished
-      # after 72h — a green run here is the last line of defence.
+      # after 72h — a green run here is the last line of defence. Lint/test run on the pristine
+      # tree *before* the version stamp: `npm pkg set` rewrites package.json (expanding single-line
+      # arrays/objects), which biome's formatter rejects — so stamping first would fail lint.
       - name: Lint
         run: pnpm lint
       - name: Tests
         run: pnpm test
       - name: RabbitMQ end-to-end tests
         run: pnpm --filter @serviceconnect/rabbitmq test:e2e
+
+      # The tag is the single source of truth for the version, so stamp it onto every workspace
+      # package immediately before publish. pnpm rewrites the internal `workspace:*` dependencies
+      # to this version on publish. Nothing embeds its own package.json version at build time, so
+      # building before the stamp (above) is safe.
+      - name: Set package versions from tag
+        run: pnpm -r exec -- npm pkg set version="${{ steps.version.outputs.version }}"
 
       - name: Publish to npm
         # --no-git-checks because the version stamp above leaves the tree dirty.


### PR DESCRIPTION
The release run for `v3.0.0-beta.1` failed at **Lint**: the `Set package versions from tag` step runs `npm pkg set version`, which rewrites every `package.json` and expands single-line arrays/objects (e.g. `"files": ["dist"]`) to multiline — which biome's formatter rejects. Lint ran *after* the stamp, so it failed for every package before publish.

Fix: reorder so the version stamp happens immediately before publish; lint/test/e2e run on the pristine, biome-clean tree. Verified locally: `pnpm build && pnpm lint && pnpm test` all pass. Nothing embeds its own package.json version at build time, so building before the stamp is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)